### PR TITLE
作業時間リスト画面のUI改善

### DIFF
--- a/app/src/main/java/com/nargok/timeclock/ui/view/effort/List.kt
+++ b/app/src/main/java/com/nargok/timeclock/ui/view/effort/List.kt
@@ -19,8 +19,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ArrowDropUp
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -110,24 +113,26 @@ fun EffortListScreen(
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.SpaceBetween,
+                        modifier = Modifier.clickable {  }
                     ) {
-                        IconButton(onClick = { viewModel.setPreviousYearMonth() }) {
-                            Icon(Icons.Default.ArrowBack, contentDescription = "Previous Month")
-                        }
-                        Text("作業記録 ${uiState.selectedYearMonth.year}/${uiState.selectedYearMonth.monthValue}")
-                        IconButton(onClick = { viewModel.setNextYearMonth() }) {
-                            Icon(Icons.Default.ArrowForward, contentDescription = "Next  Month")
-                        }
-                        IconButton(onClick = {
-                            navController.navigateToStandardWorkingHourEdit(uiState.selectedYearMonth)
-                        }) {
-                            Icon(
-                                Icons.Default.Edit,
-                                contentDescription = "Go to Standard working hours"
-                            )
-                        }
+                        Text("${uiState.selectedYearMonth.year}/${uiState.selectedYearMonth.monthValue}(Avg: ${monthlyEffort?.averageWorkingHours()}H)")
+                        Icon(
+//                            Icons.Default.ArrowDropUp,
+                            Icons.Default.ArrowDropDown,
+                            contentDescription = "Display monthly effort summary"
+                        )
                     }
                 },
+                actions = {
+                    IconButton(onClick = {
+                        navController.navigateToStandardWorkingHourEdit(uiState.selectedYearMonth)
+                    }) {
+                        Icon(
+                            Icons.Default.Settings,
+                            contentDescription = "Go to Standard working hours"
+                        )
+                    }
+                }
             )
         },
         floatingActionButton = {
@@ -154,8 +159,8 @@ fun EffortListScreen(
                                     viewModel.setNextYearMonth()
                                     isAnimating = true
                                 }
-                                offsetX > swipeThreshold ->
-                                {
+
+                                offsetX > swipeThreshold -> {
                                     swipeDirection = 1f
                                     viewModel.setPreviousYearMonth()
                                     isAnimating = true

--- a/app/src/main/java/com/nargok/timeclock/ui/view/effort/List.kt
+++ b/app/src/main/java/com/nargok/timeclock/ui/view/effort/List.kt
@@ -2,9 +2,7 @@ package com.nargok.timeclock.ui.view.effort
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
@@ -18,11 +16,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ArrowDropUp
-import androidx.compose.material.icons.filled.ArrowForward
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -41,7 +36,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,7 +51,6 @@ import com.nargok.timeclock.viewmodel.effort.EffortListViewModel
 import com.nargok.timeclock.navigation.navigateToEffortEdit
 import com.nargok.timeclock.navigation.navigateToEffortRegister
 import com.nargok.timeclock.navigation.navigateToStandardWorkingHourEdit
-import kotlinx.coroutines.launch
 import java.time.format.DateTimeFormatter
 import kotlin.math.roundToInt
 
@@ -113,14 +106,23 @@ fun EffortListScreen(
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.SpaceBetween,
-                        modifier = Modifier.clickable {  }
+                        modifier = Modifier.clickable {
+                            viewModel.toggleDisplayEffortSummary(!uiState.displayEffortSummary)
+                        }
                     ) {
                         Text("${uiState.selectedYearMonth.year}/${uiState.selectedYearMonth.monthValue}(Avg: ${monthlyEffort?.averageWorkingHours()}H)")
-                        Icon(
-//                            Icons.Default.ArrowDropUp,
-                            Icons.Default.ArrowDropDown,
-                            contentDescription = "Display monthly effort summary"
-                        )
+                        if (uiState.displayEffortSummary) {
+                            Icon(
+                                Icons.Default.ArrowDropUp,
+                                contentDescription = "Display monthly effort summary"
+                            )
+
+                        } else {
+                            Icon(
+                                Icons.Default.ArrowDropDown,
+                                contentDescription = "Display monthly effort summary"
+                            )
+                        }
                     }
                 },
                 actions = {
@@ -183,32 +185,28 @@ fun EffortListScreen(
                     Text(
                         "基準時間: ${viewModel.standardWorkingHour.value}時間(${monthlyEffort?.totalDays()}日)",
                         modifier = Modifier
-                            .padding(horizontal = 16.dp)
-                            .clickable { viewModel.toggleDisplayEffortSummary(!uiState.displayEffortSummary) },
+                            .padding(horizontal = 16.dp),
                         fontSize = 24.sp
                     )
                     Text(
                         "合計時間: ${monthlyEffort?.totalWorkingHours()}時間(${monthlyEffort?.workedDays()}日)",
                         modifier = Modifier
-                            .padding(horizontal = 16.dp)
-                            .clickable { viewModel.toggleDisplayEffortSummary(!uiState.displayEffortSummary) },
+                            .padding(horizontal = 16.dp),
                         fontSize = 24.sp
                     )
                     Text(
                         "残り日数: ${monthlyEffort?.remainingDays()}日",
                         modifier = Modifier
-                            .padding(horizontal = 16.dp)
-                            .clickable { viewModel.toggleDisplayEffortSummary(!uiState.displayEffortSummary) },
+                            .padding(horizontal = 16.dp),
+                        fontSize = 24.sp
+                    )
+                    Text(
+                        "平均: ${monthlyEffort?.averageWorkingHours()}H",
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp),
                         fontSize = 24.sp
                     )
                 }
-                Text(
-                    "平均: ${monthlyEffort?.averageWorkingHours()}H",
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .clickable { viewModel.toggleDisplayEffortSummary(!uiState.displayEffortSummary) },
-                    fontSize = 24.sp
-                )
             }
             LazyColumn(
                 contentPadding = paddingValues,

--- a/app/src/main/java/com/nargok/timeclock/ui/view/effort/List.kt
+++ b/app/src/main/java/com/nargok/timeclock/ui/view/effort/List.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
@@ -179,8 +180,7 @@ fun EffortListScreen(
                     )
                 }
         ) {
-            Column {
-                // FIXME 最初から全項目表示してもよいかも
+            Column(modifier = Modifier.padding(bottom = 8.dp)) {
                 if (uiState.displayEffortSummary) {
                     Text(
                         "基準時間: ${viewModel.standardWorkingHour.value}時間(${monthlyEffort?.totalDays()}日)",
@@ -209,10 +209,10 @@ fun EffortListScreen(
                 }
             }
             LazyColumn(
-                contentPadding = paddingValues,
+                contentPadding = PaddingValues(0.dp),
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(16.dp),
+                    .padding(horizontal = 16.dp),
             ) {
                 items(monthlyEffort?.effortList() ?: emptyList()) { effort ->
                     EffortListItem(effort) {

--- a/app/src/main/java/com/nargok/timeclock/ui/view/effort/List.kt
+++ b/app/src/main/java/com/nargok/timeclock/ui/view/effort/List.kt
@@ -3,6 +3,7 @@ package com.nargok.timeclock.ui.view.effort
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -29,9 +30,13 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -55,6 +60,9 @@ fun EffortListScreen(
     val uiState = viewModel.uiState
     val monthlyEffort by viewModel.monthlyEfforts
     val snackBarHostState = remember { SnackbarHostState() }
+
+    var offsetX by remember { mutableFloatStateOf(0f) }
+    val swipeThreshold = 100f
 
     LaunchedEffect(Unit) {
         viewModel.fetchMonthlyEfforts()
@@ -113,6 +121,21 @@ fun EffortListScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .pointerInput(Unit) {
+                    detectHorizontalDragGestures(
+                        onDragEnd = {
+                            when {
+                                offsetX < -swipeThreshold -> viewModel.setNextYearMonth()
+                                offsetX > swipeThreshold -> viewModel.setPreviousYearMonth()
+                            }
+                            offsetX = 0f
+                        },
+                        onDragCancel = { offsetX = 0f },
+                        onHorizontalDrag = { _, dragAmount ->
+                            offsetX += dragAmount
+                        }
+                    )
+                }
         ) {
             Column {
                 // FIXME 最初から全項目表示してもよいかも

--- a/app/src/main/java/com/nargok/timeclock/viewmodel/effort/List.kt
+++ b/app/src/main/java/com/nargok/timeclock/viewmodel/effort/List.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nargok.timeclock.domain.model.EffortModel
 import com.nargok.timeclock.domain.model.EffortSearchCondition
 import com.nargok.timeclock.domain.model.MonthlyEffortModel
 import com.nargok.timeclock.domain.model.vo.StandardWorkingHour


### PR DESCRIPTION
- スワイプによる月移動の挙動を実装する
- レイアウト変更
    - ヘッダー
        - タイトルの表示内容を月と平均時間
            - 1月(avg 8.2H) ↓(↑)
        - 矢印を消す
        - 鉛筆を消す
        - アクションボタンを設定歯車アイコンにする
    - 月次サマリの表示ON・OFFのトリガー改善
        - ヘッダのタイトルをタップ
        - トータル時間とかが出てくる
    - 月次サマリと作業時間リストの間に隙間調整